### PR TITLE
Chocolatey package installation may have more args than just its name

### DIFF
--- a/New-Machine.ps1
+++ b/New-Machine.ps1
@@ -11,15 +11,15 @@ else
 }
 
 $ExistingChocoPackages = (& choco list -localonly) | % { $_.Split(' ')[0] }
-function Install-ChocoIfNotAlready($name) {
-    if ($ExistingChocoPackages -contains $name)
+function Install-ChocoIfNotAlready() {
+    if ($ExistingChocoPackages -contains $($args[0]))
     {
-        "$name already installed"
+        "($args[0]) already installed"
     }
     else
     {
-        "Installing $name"
-        & choco install $name
+        "Installing ($args[0])"
+        & choco install $args
     }
 }
 


### PR DESCRIPTION
ok, this may be wrong but this mod is to cater for any number (>=1) args in the Chocolatey install command that may specify `-version` `-source` etc.

**Untested** because $corp Productivity Firewall [TM]
