### PR TITLE
Update Google Chrome Chocolatey package

### DIFF
--- a/New-Machine.ps1
+++ b/New-Machine.ps1
@@ -25,7 +25,7 @@ if (-not ((Get-PackageSource -Name chocolatey).IsTrusted)) {
 }
 
 @(
-    "google-chrome-x64",
+    "googlechrome",
     "git.install",
     "visualstudiocode",
     "fiddler4",


### PR DESCRIPTION
The old package is deprecated: https://chocolatey.org/packages/google-chrome-x64

The new one will automatically install the 64-bit version for 64-bit OSes: 
https://chocolatey.org/packages/GoogleChrome