### PR TITLE
Updates to Chocolatey packages

### DIFF
--- a/New-Machine.ps1
+++ b/New-Machine.ps1
@@ -25,10 +25,9 @@ if (-not ((Get-PackageSource -Name chocolatey).IsTrusted)) {
 }
 
 @(
-    "google-chrome-x64",
+    "googlechrome",
     "git.install",
-    "visualstudiocode",
-    "fiddler4",
+    "vscode",
     "slack",
     "snagit"
 ) | % {


### PR DESCRIPTION
google-chrome-x64 and visualstudiocode were marked as deprecated, and fiddler4 was removed as requested by Telerik

New packages:
https://chocolatey.org/packages/googlechrome
https://chocolatey.org/packages/vscode

Deprecated packages:
https://chocolatey.org/packages/google-chrome-x64
https://chocolatey.org/packages/VisualStudioCode

Unlisted/hidden package:
https://chocolatey.org/packages/fiddler4